### PR TITLE
More than one group is crashing on iOS

### DIFF
--- a/src/XFExpandableListView/Controls/ExpandableListView.cs
+++ b/src/XFExpandableListView/Controls/ExpandableListView.cs
@@ -110,19 +110,6 @@ namespace XFExpandableListView.Controls
                     itemsSource.Add(item.NewInstance());
                 }
 
-                // Expand items (iOS fix)
-                //for (var i = 0; i < items.Count; i++)
-                //{
-                //    var group = (IExpandableGroup)items[i];
-                //    var itemsSourceGroup = (IExpandableGroup)itemsSource[i];
-                //    if (!group.IsExpanded) continue;
-
-                //    foreach (var item in group)
-                //    {
-                //        itemsSourceGroup.Add(item);
-                //    }
-                //}
-
                 control.ItemsSource = itemsSource;
             });
 
@@ -304,9 +291,10 @@ namespace XFExpandableListView.Controls
                         itemsSourceGroup.Add(item);
                     }
                 }
-
+            }).ContinueWith((task) =>
+            {
                 ItemsSource = updatedItemsSource;
-            });
+            }, TaskScheduler.FromCurrentSynchronizationContext());
         }
 
         #endregion

--- a/src/XFExpandableListView/Controls/ExpandableListView.cs
+++ b/src/XFExpandableListView/Controls/ExpandableListView.cs
@@ -293,8 +293,11 @@ namespace XFExpandableListView.Controls
                 }
             }).ContinueWith((task) =>
             {
-                ItemsSource = updatedItemsSource;
-            }, TaskScheduler.FromCurrentSynchronizationContext());
+                Device.BeginInvokeOnMainThread(() =>
+                {
+                    ItemsSource = updatedItemsSource;
+                });
+            });
         }
 
         #endregion

--- a/src/XFExpandableListView/Controls/ExpandableListView.cs
+++ b/src/XFExpandableListView/Controls/ExpandableListView.cs
@@ -291,15 +291,14 @@ namespace XFExpandableListView.Controls
                         itemsSourceGroup.Add(item);
                     }
                 }
-            }).ContinueWith((task) =>
-            {
+
                 Device.BeginInvokeOnMainThread(() =>
                 {
                     ItemsSource = updatedItemsSource;
                 });
             });
-        }
 
-        #endregion
+            #endregion
+        }
     }
 }


### PR DESCRIPTION
Hi Dionysis,

Found your repo being very useful for the task of expanding groups. But it was crashing on iOS when I tried to run it there. So here is a small fix.

Basically the issue was in `UpdateExpandedItems()` when groups were dynamically updated right inside ListView. This is ok for Android but on iOS the implementation is such that it makes all the operations being run in item update cycle. When combined with initial item set it leads to the following error:

```Objective-C exception thrown.  Name: NSInternalInconsistencyException Reason: Invalid update: invalid number of rows in section 1.  The number of rows contained in an existing section after the update (2) must be equal to the number of rows contained in that section before the update (0), plus or minus the number of rows inserted or deleted from that section (0 inserted, 0 deleted) and plus or minus the number of rows moved into or out of that section (0 moved in, 0 moved out).```

I made the update work in the manner that items are set at the end of normalization of their state. That fixes the issue. Maybe it'll make sense to add iOS project to the example. If you want, I can do it in next PR.

Thanks for the hard work you've done!